### PR TITLE
Update dictionary.pyx to work with python3.10

### DIFF
--- a/av/dictionary.pyx
+++ b/av/dictionary.pyx
@@ -1,4 +1,9 @@
-import collections
+try:
+    # python3.10 and later
+    from collections.abc import MutableMapping
+except ImportError:
+    # python3.8
+    from collections import MutableMapping
 
 from av.error cimport err_check
 
@@ -48,7 +53,7 @@ cdef class _Dictionary(object):
         return other
 
 
-class Dictionary(_Dictionary, collections.MutableMapping):
+class Dictionary(_Dictionary, MutableMapping):
     pass
 
 


### PR DESCRIPTION
ubuntu 22.04 ships with python3.10 as default, in python3.10 MutableMapping is moved to collections.abc